### PR TITLE
Add ability to retrieve URL report URL for download

### DIFF
--- a/src/Api/Crawl.php
+++ b/src/Api/Crawl.php
@@ -522,6 +522,42 @@ class Crawl
     }
 
     /**
+     * Sets the request type to "urls" to retrieve the URL Report
+     * URL for understanding diagnostic data of URLs 
+     *
+     * @return $this
+     */
+    public function getUrlReportUrl($num = null)
+    {
+        $this->otherOptions['type'] = 'urls';
+
+        if (!empty($num) && is_numeric($num)) {
+           $this->otherOptions['num'] = $num; 
+        }
+
+        // Setup data endpoint
+        $url = $this->apiUrl . '/data';
+
+        // Add token
+        $url .= '?token=' . $this->diffbot->getToken();
+
+        if ($this->getName()) {
+            // Add name
+            $url .= '&name=' . $this->getName();
+
+            // Add other options
+            if (!empty($this->otherOptions)) {
+                foreach ($this->otherOptions as $option => $value) {
+                    $url .= '&' . $option . '=' . $value;
+                }
+            }
+        }
+
+        return $url;
+
+    }
+
+    /**
      * @return string
      */
     protected function getApiString()


### PR DESCRIPTION
This adds the ability to retrieve the URL to download the URL report. Example usage:

```php
$diffbot = new Diffbot(MY_TOKEN_HERE);
$crawl = $diffbot->crawl('SomeCrawlNameHere');
$url_report = $crawl->getUrlReportUrl();

// show the url to the url report
echo $url_report;
```