### PR TITLE
Space needs to be encoded to allow multi-seeds

### DIFF
--- a/src/Api/Crawl.php
+++ b/src/Api/Crawl.php
@@ -502,7 +502,7 @@ class Crawl
 
             // Add seeds
             if (!empty($this->seeds)) {
-                $url .= '&seeds=' . implode(' ', array_map(function ($item) {
+                $url .= '&seeds=' . implode('%20', array_map(function ($item) {
                     return urlencode($item);
                 }, $this->seeds));
             }


### PR DESCRIPTION
When setting multiple seed URLs this program fails because the space separating them needs to be URL encoded itself.