### PR TITLE
Handle Cases in Product where Text Does Not Exist

### DIFF
--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -37,11 +37,11 @@ class Product extends Entity
 
     /**
      * Text description, if available, of the product
-     * @return string
+     * @return string|null
      */
     public function getText()
     {
-        return $this->data['text'];
+        return (isset($this->data['text'])) ? $this->data['text'] : null;
     }
 
     /**


### PR DESCRIPTION
There are cases where returning a Product Entity, the text field does not exist. This catches that issue.

Resolves Issue #61 